### PR TITLE
[REFINE]：放在括弧内会导致Jar每目录下都多余一个同目录名的空文件，可能会导致相关错误，另外从时机考虑也该如此。

### DIFF
--- a/plugin/src/main/groovy/com/sankuai/waimai/router/plugin/WMRouterServiceProcessor.java
+++ b/plugin/src/main/groovy/com/sankuai/waimai/router/plugin/WMRouterServiceProcessor.java
@@ -262,8 +262,7 @@ public class WMRouterServiceProcessor {
             if (hasServiceEntry(zipFile)) {
                 WMRouterLogger.debug(SERVICE_META + "    found service entry, modify jar file");
                 File tempFile = new File(jarFile.getPath() + ".tmp");
-                try (ZipInputStream is = new ZipInputStream(new FileInputStream(jarFile));
-                     ZipOutputStream os = new ZipOutputStream(new FileOutputStream(tempFile))) {
+                try (ZipInputStream is = new ZipInputStream(new FileInputStream(jarFile))) {
                     ZipEntry entry;
                     while ((entry = is.getNextEntry()) != null) {
                         if (isServiceEntry(entry)) {
@@ -276,8 +275,10 @@ public class WMRouterServiceProcessor {
                                 e.printStackTrace();
                             }
                         } else {
+                            ZipOutputStream os = new ZipOutputStream(new FileOutputStream(tempFile));
                             os.putNextEntry(new ZipEntry(entry));
                             IOUtils.copy(is, os);
+                            os.close();
                         }
                     }
                     jarFile.delete();


### PR DESCRIPTION
Jar中存在目录与文件同名时会出现错误。