### PR TITLE
对应@RouterPage注解的Activity的启动，自动拼装PageAnnotationHandler.SCHEME_HOST和path

### DIFF
--- a/router/src/main/java/com/sankuai/waimai/router/Router.java
+++ b/router/src/main/java/com/sankuai/waimai/router/Router.java
@@ -6,6 +6,7 @@ import android.os.Looper;
 import android.support.annotation.NonNull;
 
 import com.sankuai.waimai.router.annotation.RouterProvider;
+import com.sankuai.waimai.router.common.PageAnnotationHandler;
 import com.sankuai.waimai.router.core.RootUriHandler;
 import com.sankuai.waimai.router.core.Debugger;
 import com.sankuai.waimai.router.core.UriRequest;
@@ -84,6 +85,15 @@ public class Router {
 
     public static void startUri(Context context, String uri) {
         getRootHandler().startUri(new UriRequest(context, uri));
+    }
+
+    /**
+     * 启动@RouterPage注解的Activity，自动拼装PageAnnotationHandler.SCHEME_HOST和path
+     * @param context
+     * @param path
+     */
+    public static void startPageUri(Context context, String path) {
+        startUri(context, PageAnnotationHandler.SCHEME_HOST + path);
     }
 
     /**

--- a/router/src/main/java/com/sankuai/waimai/router/common/DefaultPageUriRequest.java
+++ b/router/src/main/java/com/sankuai/waimai/router/common/DefaultPageUriRequest.java
@@ -1,0 +1,22 @@
+package com.sankuai.waimai.router.common;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import java.util.HashMap;
+
+/**
+ * 对应@RouterPage的默认封装子类，自动拼装PageAnnotationHandler.SCHEME_HOST和path，避免每次都要手动拼装
+ * Created by liaohailiang on 2018/9/27.
+ */
+public class DefaultPageUriRequest extends DefaultUriRequest {
+
+    public DefaultPageUriRequest(@NonNull Context context, @NonNull String path) {
+        super(context, PageAnnotationHandler.SCHEME_HOST + path);
+    }
+
+    public DefaultPageUriRequest(@NonNull Context context, @NonNull String path,
+                                 HashMap<String, Object> extra) {
+        super(context, PageAnnotationHandler.SCHEME_HOST + path, extra);
+    }
+}


### PR DESCRIPTION
@RouterPage注解的Activity的启动，对于原有的方式，每次都需要手动拼装PageAnnotationHandler.SCHEME_HOST和path，不是很方便。增加了一个DefaultPageUriRequest类，另外，在Router中增加了一个startPageUri方法，对应@RouterPage的启动，有两种方法：
1、// 对应RouterPage的配置
Router.startPageUri(context,  "/account");
2、new DefaultPageUriRequest(this, uri)
                    ...
                    .start();