### PR TITLE
修复 URI 分发路径不匹配问题

### DIFF
--- a/router/src/main/java/com/sankuai/waimai/router/common/PathHandler.java
+++ b/router/src/main/java/com/sankuai/waimai/router/common/PathHandler.java
@@ -94,6 +94,7 @@ public class PathHandler extends UriHandler {
         if (TextUtils.isEmpty(path)) {
             return null;
         }
+        path = RouterUtils.appendSlash(path);
         if (TextUtils.isEmpty(mPathPrefix)) {
             return mMap.get(path);
         }


### PR DESCRIPTION
# 描述

使用 `RouterUri` 注解, 当 `path` 不是以 `/` 字符开头时, 出现 404 找不到路径错误。

# 分析

以下为 `PathHandler` 部分代码:

* 注册节点

```java
public void register(String path, Object target, boolean exported,
            UriInterceptor... interceptors) {
    if (!TextUtils.isEmpty(path)) {
        // path 添加斜线前缀
        path = RouterUtils.appendSlash(path);
        UriHandler parse = UriTargetTools.parse(target, exported, interceptors);
        // 注册 path
        UriHandler prev = mMap.put(path, parse);
        if (prev != null) {
            Debugger.fatal("[%s] 重复注册path='%s'的UriHandler: %s, %s", this, path, prev, parse);
        }
    }
}
```

* 查找节点

```java
private UriHandler getChild(@NonNull UriRequest request) {
    // 未添加斜线前缀的 path
    String path = request.getUri().getPath();
    if (TextUtils.isEmpty(path)) {
        return null;
    }
    if (TextUtils.isEmpty(mPathPrefix)) {
        return mMap.get(path);
    }
    if (path.startsWith(mPathPrefix)) {
        return mMap.get(path.substring(mPathPrefix.length()));
    }
    return null;
}
```

由于无法正常查找对应的节点, 抛出 404
