### PR TITLE
修复多模块下 dex archive merge 失败问题

### DIFF
--- a/compiler/src/main/java/com/sankuai/waimai/router/compiler/BaseProcessor.java
+++ b/compiler/src/main/java/com/sankuai/waimai/router/compiler/BaseProcessor.java
@@ -15,6 +15,7 @@ import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
+import java.util.UUID;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
@@ -120,6 +121,10 @@ public abstract class BaseProcessor extends AbstractProcessor {
 
     public boolean isInterceptor(Element element) {
         return isConcreteSubType(element, Const.URI_INTERCEPTOR_CLASS);
+    }
+
+    public static String randomHash() {
+        return hash(UUID.randomUUID().toString());
     }
 
     public static String hash(String str) {

--- a/compiler/src/main/java/com/sankuai/waimai/router/compiler/PageAnnotationProcessor.java
+++ b/compiler/src/main/java/com/sankuai/waimai/router/compiler/PageAnnotationProcessor.java
@@ -63,6 +63,9 @@ public class PageAnnotationProcessor extends BaseProcessor {
                         interceptors);
             }
         }
+        if (hash == null) {
+            hash = randomHash();
+        }
         buildHandlerInitClass(builder.build(), "PageAnnotationInit" + Const.SPLITTER + hash,
                 Const.PAGE_ANNOTATION_HANDLER_CLASS, Const.PAGE_ANNOTATION_INIT_CLASS);
         return true;

--- a/compiler/src/main/java/com/sankuai/waimai/router/compiler/RegexAnnotationProcessor.java
+++ b/compiler/src/main/java/com/sankuai/waimai/router/compiler/RegexAnnotationProcessor.java
@@ -63,6 +63,9 @@ public class RegexAnnotationProcessor extends BaseProcessor {
                     interceptors
             );
         }
+        if (hash == null) {
+            hash = randomHash();
+        }
         buildHandlerInitClass(builder.build(), "RegexAnnotationInit" + Const.SPLITTER + hash,
                 Const.REGEX_ANNOTATION_HANDLER_CLASS, Const.REGEX_ANNOTATION_INIT_CLASS);
         return true;

--- a/compiler/src/main/java/com/sankuai/waimai/router/compiler/UriAnnotationProcessor.java
+++ b/compiler/src/main/java/com/sankuai/waimai/router/compiler/UriAnnotationProcessor.java
@@ -66,6 +66,9 @@ public class UriAnnotationProcessor extends BaseProcessor {
                         interceptors);
             }
         }
+        if (hash == null) {
+            hash = randomHash();
+        }
         buildHandlerInitClass(builder.build(), "UriAnnotationInit" + Const.SPLITTER + hash,
                 Const.URI_ANNOTATION_HANDLER_CLASS, Const.URI_ANNOTATION_INIT_CLASS);
         return true;


### PR DESCRIPTION
## 描述
多模块开发环境下, 当有 2 个或 2 个以上模块依赖 WMrouter, 且这几个模块均没有配置 `RouterUri` 注解(或 `RouterRegex` 等等), 出现 `DexArchiveMergerException` 异常。

该异常的直接表述如下: 
Error: Program type already present: com.sankuai.waimai.router.generated.UriAnnotationInit_null

## 分析
以下部分以 `RouterUri` 注解处理器 `UriAnnotationProcessor` 分析:

* `UriAnnotationProcessor` 类的 `process` 函数代码

```java
public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment env) {
    if (annotations == null || annotations.isEmpty()) {
        return false;
    }
    CodeBlock.Builder builder = CodeBlock.builder();
    String hash = null;
    // 当模块下没有配置 RouterUri 注解时, 不会执行循环内代码
    for (Element element : env.getElementsAnnotatedWith(RouterUri.class)) {
        ...

        if (hash == null) {
            hash = hash(cls.className());
        }

        ...
    }
    // 若以上循环内代码未执行, 此时 hash = null
    // "UriAnnotationInit" + Const.SPLITTER + hash = UriAnnotationInit_null
    buildHandlerInitClass(builder.build(), "UriAnnotationInit" + Const.SPLITTER + hash,
            Const.URI_ANNOTATION_HANDLER_CLASS, Const.URI_ANNOTATION_INIT_CLASS);
    return true;
}
```

当模块内部没有任何组件配置 `RouterUri` 注解时, 该注解处理器将在固定的 `package` 下默认生成 `UriAnnotationInit_null` 类

当存在 2 个或 2 个以上的模块均没有配置 `RouterUri` 注解时, 在固定的 `package` 下将同时存在 2 个或 2 个以上的 `UriAnnotationInit_null` 类，此时将导致 `DexArchiveMergerException` 异常。

其他注解处理器问题与以上类似。