### PR TITLE
修复非增量编译的缺陷

### DIFF
--- a/plugin/src/main/groovy/com/sankuai/waimai/router/plugin/WMRouterTransform.java
+++ b/plugin/src/main/groovy/com/sankuai/waimai/router/plugin/WMRouterTransform.java
@@ -80,7 +80,14 @@ public class WMRouterTransform extends Transform {
     public void transform(TransformInvocation invocation) {
         WMRouterLogger.info(TRANSFORM + "start...");
         long ms = System.currentTimeMillis();
-
+        //非增量编译，先清空输出目录
+        if(!invocation.isIncremental()){
+            try {
+                invocation.getOutputProvider().deleteAll();
+            } catch (IOException e) {
+                WMRouterLogger.fatal(e);
+            }
+        }
         Set<String> initClasses = Collections.newSetFromMap(new ConcurrentHashMap<>());
         Set<String> deleteClasses = Collections.newSetFromMap(new ConcurrentHashMap<>());
         BaseTransform baseTransform = new BaseTransform(invocation, new TransformCallBack() {


### PR DESCRIPTION
# 问题
进行一次完整编译，然后修改一个lib的版本号，不clean工程直接编译，WMRouter同时保留修改前后的lib，导致最后merge dex的时候类重复。
# 修复方案
在进行非增量编译的时候，先清空输出目录。

已经自测，没有问题。