### PR TITLE
fix: WMRouterTransform 遗漏 JarInput 中 ServiceInit_$

### DIFF
--- a/plugin/src/main/groovy/com/sankuai/waimai/router/plugin/WMRouterTransform.java
+++ b/plugin/src/main/groovy/com/sankuai/waimai/router/plugin/WMRouterTransform.java
@@ -94,8 +94,9 @@ public class WMRouterTransform extends Transform {
             @Override
             public byte[] process(String className, byte[] bytes, BaseTransform baseTransform) {
                 String checkClassName = ClassUtils.path2Classname(className);
-                if (checkClassName.startsWith(Const.GEN_PKG_SERVICE)) {
+                if (checkClassName.startsWith(Const.GEN_PKG_SERVICE) || checkClassName.startsWith(INIT_SERVICE_PATH)) {
                     initClasses.add(className);
+                    WMRouterLogger.info("    find ServiceInitClass: %s", className);
                 }
                 return null;
             }
@@ -104,8 +105,9 @@ public class WMRouterTransform extends Transform {
             @Override
             public void delete(String className, byte[] bytes) {
                 String checkClassName = ClassUtils.path2Classname(className);
-                if (checkClassName.startsWith(Const.GEN_PKG_SERVICE)) {
+                if (checkClassName.startsWith(Const.GEN_PKG_SERVICE) || checkClassName.startsWith(INIT_SERVICE_PATH)) {
                     deleteClasses.add(className);
+                    WMRouterLogger.info("    find ServiceInitClass: %s", className);
                 }
             }
         });


### PR DESCRIPTION
JarInput 中的 filename 格式为 com/sankuai/waimai/router/generated/service/ServiceInit_27c543960bb6e7e43b7e7c9554e68407.class，导致 WMRouterTransform 遗漏这部分类的 init 调用。