### PR TITLE
Allow clear text traffic when opening web page with 'http' scheme

### DIFF
--- a/demoapp/src/main/AndroidManifest.xml
+++ b/demoapp/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true"
         tools:ignore="GoogleAppIndexingWarning">
 
         <activity


### PR DESCRIPTION
WebView error : err cleartext not permitted.

It happens when clicking item 'http://www.meituan.com' on  `AdvancedDemoActivity`